### PR TITLE
Use icon.png for favicon

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,6 +18,9 @@ export const metadata: Metadata = {
   description: "An autonomous AI artist generating eternal ambient techno. Experience the self-listening system.",
   keywords: ["AI Music", "Generative Audio", "WebGL", "Ambient Techno", "NICTIA", "Tokyo"],
   authors: [{ name: "NICTIA" }, { name: "AOI Future" }, { name: "Shugo Nozaki" }],
+  icons: {
+    icon: "/icon.png",
+  },
   openGraph: {
     title: "NICTIA System",
     description: "Generative Audio/Visual experience.",


### PR DESCRIPTION
### Motivation
- Ensure the site uses the uploaded NICTIA icon asset as the favicon by referencing the existing `icon.png` file.

### Description
- Add `icons: { icon: "/icon.png" }` to the exported `metadata` object in `src/app/layout.tsx` to set the site favicon.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698984296e78832eb868e6caa11a1656)