### PR TITLE
Further reduce first-load wait and browser freezes during initialization

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ import dynamic from "next/dynamic";
 import {
   initToneContext,
   initAudioLight,
-  initAudioFull,
+  initAudioFullDeferred,
   startAudio,
   stopAudio,
   getIsPlaying,
@@ -266,7 +266,7 @@ export default function Home() {
       setIsInitialized(true);
 
       // Background: Initialize full audio (reverb) without blocking
-      initAudioFull();
+      initAudioFullDeferred();
     } catch (error) {
       console.error("Failed to initialize:", error);
       setPhase("idle");


### PR DESCRIPTION
### Motivation
- The app still experienced long first-load waits and occasional browser freezes when generating heavy audio effects and running per-frame FFT reductions. 
- Move expensive work off the hot path and reduce per-frame CPU pressure in audio-reactive visuals to improve initialization responsiveness on constrained devices.

### Description
- Added an adaptive `AudioProfile` and `getAudioProfile()` to tune analyser sizes, waveform bins, loop intervals, and `skipReverb` for low-memory/mobile/Save-Data/`prefers-reduced-motion` environments, and applied `context.lookAhead = 0.05` to the Tone context. 
- Deferred full audio initialization by introducing `initAudioFullDeferred()` which uses `requestIdleCallback` (with a timeout and `setTimeout` fallback) and updated initialization flows (`initAudio()` and page startup) to call the deferred path so reverb generation runs off the main interactive path. 
- Hardened reverb setup with a timeout and safe fallback that disposes reverb on failure and respects `skipReverb` for constrained profiles. 
- Implemented `getAudioIntensity()` with throttled FFT aggregation (~30fps) and half-bin sampling, switched analyser/waveform sizes to use profile values, and updated `Visualizer` animations to use the shared cached intensity helper; also extended `Visualizer` perf config with `fragmentCount`, `enableShadows`, and `powerPreference`, and routed those into the `Canvas` and `OrbitingCovers` props.

### Testing
- Ran lint with `npm run lint` and it completed successfully. 
- Attempted production build with `npm run build`, which failed due to inability to fetch Google Fonts (`Geist` / `Geist Mono`) in this environment (external resource fetch issue), not due to the functional changes. 
- Started dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000` and it started successfully. 
- Automated Playwright script opened `http://127.0.0.1:3000`, clicked `INITIALIZE SYSTEM`, and captured a screenshot to validate the lightweight init path (screenshot produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990149d01c4832e8fa1d53edc53a747)