### PR TITLE
Update homepage YouTube live URL

### DIFF
--- a/public/data/status.json
+++ b/public/data/status.json
@@ -29,7 +29,7 @@
   "radio": {
     "enabled": true,
     "label": "24/7 RADIO",
-    "url": "https://www.youtube.com/watch?v=BKJlvw8Iz_s"
+    "url": "https://www.youtube.com/live/MfoeW59iaU0?si=3GYZATovq_wPRjAa"
   },
   "discography": {
     "channelUrl": "https://www.youtube.com/channel/UCrS9TtbbKn3rpN_KWd-u3_A",


### PR DESCRIPTION
### Motivation
- The homepage "24/7 RADIO" YouTube link was outdated and needs to be replaced with the provided live URL.

### Description
- Updated `radio.url` in `public/data/status.json` to `https://www.youtube.com/live/MfoeW59iaU0?si=3GYZATovq_wPRjAa`, modifying only that file.

### Testing
- Ran `jq empty public/data/status.json` to validate the JSON and inspected `git diff -- public/data/status.json`, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699067eeac9c832eb6848490a778b612)