### PR TITLE
fix: use dynamic import for eslint-config-next to fix ESM resolution

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,9 +1,7 @@
-import { createRequire } from "node:module";
 import { defineConfig, globalIgnores } from "eslint/config";
 
-const require = createRequire(import.meta.url);
-const nextVitals = require("eslint-config-next/core-web-vitals");
-const nextTs = require("eslint-config-next/typescript");
+const nextVitals = (await import("eslint-config-next/core-web-vitals")).default;
+const nextTs = (await import("eslint-config-next/typescript")).default;
 
 const reactRuleOverrides = Object.fromEntries(
   [...nextVitals, ...nextTs]


### PR DESCRIPTION
Fixes ERR_MODULE_NOT_FOUND in CI by using dynamic import for eslint-config-next subpaths.