### PR TITLE
fix(eslint): robustly import eslint-config-next with fallback for ESM versions

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,18 +1,45 @@
 import { defineConfig, globalIgnores } from "eslint/config";
+import { createRequire } from "node:module";
 
-const nextVitals = (await import("eslint-config-next/core-web-vitals")).default;
-const nextTs = (await import("eslint-config-next/typescript")).default;
+const require = createRequire(import.meta.url);
+
+async function loadNextConfig(moduleName) {
+  try {
+    // Next 16+ (ESM with exports map)
+    const mod = await import(moduleName);
+    return mod.default || mod;
+  } catch (err) {
+    // Next 15 (ESM without exports map requires .js extension)
+    if (err.code === "ERR_PACKAGE_PATH_NOT_EXPORTED") {
+      try {
+        const mod = await import(`${moduleName}.js`);
+        return mod.default || mod;
+      } catch {
+        // Fallback to CJS require
+        return require(moduleName);
+      }
+    }
+    // Fallback to CJS require
+    return require(moduleName);
+  }
+}
+
+const nextVitals = await loadNextConfig("eslint-config-next/core-web-vitals");
+const nextTs = await loadNextConfig("eslint-config-next/typescript");
 
 const reactRuleOverrides = Object.fromEntries(
-  [...nextVitals, ...nextTs]
+  [
+    ...(Array.isArray(nextVitals) ? nextVitals : [nextVitals]),
+    ...(Array.isArray(nextTs) ? nextTs : [nextTs]),
+  ]
     .flatMap((config) => Object.keys(config.rules ?? {}))
     .filter((rule) => rule.startsWith("react/"))
     .map((rule) => [rule, "off"]),
 );
 
 const eslintConfig = defineConfig([
-  ...nextVitals,
-  ...nextTs,
+  ...(Array.isArray(nextVitals) ? nextVitals : [nextVitals]),
+  ...(Array.isArray(nextTs) ? nextTs : [nextTs]),
   {
     rules: reactRuleOverrides,
   },


### PR DESCRIPTION
This PR fixes the ESLint import error (`ERR_PACKAGE_PATH_NOT_EXPORTED`) by implementing a robust import mechanism that handles both Next.js 15 (which might require `.js` extension or CJS fallback) and Next.js 16 (which uses ESM exports map).

Testing:
- Verified locally with `npm run lint` (Next 16.2.1)
- Implemented error handling for `ERR_PACKAGE_PATH_NOT_EXPORTED`
- Added CJS fallback via `createRequire`