### PR TITLE
fix: explicit eslint-config-next subpath imports for flat config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,18 +1,45 @@
 import { defineConfig, globalIgnores } from "eslint/config";
+import { createRequire } from "node:module";
 
-const nextVitals = (await import("eslint-config-next/core-web-vitals")).default;
-const nextTs = (await import("eslint-config-next/typescript")).default;
+const require = createRequire(import.meta.url);
+
+async function loadNextConfig(moduleName) {
+  try {
+    // Next 16+ (ESM with exports map)
+    const mod = await import(moduleName);
+    return mod.default || mod;
+  } catch (err) {
+    // Next 15 (ESM without exports map requires .js extension)
+    if (err.code === "ERR_PACKAGE_PATH_NOT_EXPORTED") {
+      try {
+        const mod = await import(`${moduleName}.js`);
+        return mod.default || mod;
+      } catch {
+        // Fallback to CJS require
+        return require(moduleName);
+      }
+    }
+    // Fallback to CJS require
+    return require(moduleName);
+  }
+}
+
+const nextVitals = await loadNextConfig("eslint-config-next/core-web-vitals");
+const nextTs = await loadNextConfig("eslint-config-next/typescript");
 
 const reactRuleOverrides = Object.fromEntries(
-  [...nextVitals, ...nextTs]
+  [
+    ...(Array.isArray(nextVitals) ? nextVitals : [nextVitals]),
+    ...(Array.isArray(nextTs) ? nextTs : [nextTs]),
+  ]
     .flatMap((config) => Object.keys(config.rules ?? {}))
     .filter((rule) => rule.startsWith("react/"))
     .map((rule) => [rule, "off"]),
 );
 
 const eslintConfig = defineConfig([
-  ...nextVitals,
-  ...nextTs,
+  ...(Array.isArray(nextVitals) ? nextVitals : [nextVitals]),
+  ...(Array.isArray(nextTs) ? nextTs : [nextTs]),
   {
     rules: reactRuleOverrides,
   },


### PR DESCRIPTION
This PR fixes the `ERR_PACKAGE_PATH_NOT_EXPORTED` error by providing a robust loading mechanism for `eslint-config-next` subpaths in `eslint.config.mjs`. It handles both newer Next.js versions (with export maps) and older ones (requiring explicit extensions or CJS fallback).