### PR TITLE
fix: prevent regression on eslint-config-next imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,7 +1,7 @@
 import { defineConfig, globalIgnores } from "eslint/config";
 
-const nextVitals = (await import("eslint-config-next/core-web-vitals")).default;
-const nextTs = (await import("eslint-config-next/typescript")).default;
+const nextVitals = (await import("eslint-config-next/core-web-vitals")).default; // Do not add .js extension here!
+const nextTs = (await import("eslint-config-next/typescript")).default; // Do not add .js extension here!
 
 const reactRuleOverrides = Object.fromEntries(
   [...nextVitals, ...nextTs]


### PR DESCRIPTION
This PR adds a comment to prevent adding `.js` extensions to `eslint-config-next` subpath imports, as the package's `exports` map does not define it and doing so will result in `ERR_PACKAGE_PATH_NOT_EXPORTED`. This prevents the regression seen in GitHub Actions run 23870711913.